### PR TITLE
got rid of webkit-backface-visibility from css

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -20,7 +20,6 @@ export default {
     .img{
         width: 30%;
         /*Re-renders image so that it is easier to code*/
-        -webkit-backface-visibility: hidden;
         -ms-transform: translateZ(0); /* IE 9 */
         -webkit-transform: translateZ(0); /* Chrome, Safari, Opera */
         transform: translateZ(0);


### PR DESCRIPTION
got rid of webkit-backface-visibility from css as it is causing an error message and is not needed for our implementation of making the image less blurry. (it's inteded for hiding the backside of images that are rotated. It also requires additional definition of backface-visibility to work, thus, an error message.)